### PR TITLE
Add LDAP as source

### DIFF
--- a/cmd/headscale-pf/prepare.go
+++ b/cmd/headscale-pf/prepare.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+
 	"github.com/yousysadmin/headscale-pf/internal/models"
 	"github.com/yousysadmin/headscale-pf/internal/policy"
 	"github.com/yousysadmin/headscale-pf/internal/sources"

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,11 @@ require (
 )
 
 require (
+	github.com/Azure/go-ntlmssp v0.0.0-20221128193559-754e69321358 // indirect
+	github.com/go-asn1-ber/asn1-ber v1.5.8-0.20250403174932-29230038a667 // indirect
+)
+
+require (
 	atomicgo.dev/cursor v0.2.0 // indirect
 	atomicgo.dev/keyboard v0.2.9 // indirect
 	atomicgo.dev/schedule v0.1.0 // indirect
@@ -23,6 +28,7 @@ require (
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/go-jose/go-jose/v4 v4.1.0 // indirect
 	github.com/go-json-experiment/json v0.0.0-20250223041408-d3c622f1b874 // indirect
+	github.com/go-ldap/ldap/v3 v3.4.11
 	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-openapi/analysis v0.23.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -41,6 +41,8 @@ cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 filippo.io/edwards25519 v1.1.0 h1:FNf4tywRC1HmFuKW5xopWpigGjJKiJSV0Cqo0cJWDaA=
 filippo.io/edwards25519 v1.1.0/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=
+github.com/Azure/go-ntlmssp v0.0.0-20221128193559-754e69321358 h1:mFRzDkZVAjdal+s7s0MwaRv9igoPqLRdzOLzw/8Xvq8=
+github.com/Azure/go-ntlmssp v0.0.0-20221128193559-754e69321358/go.mod h1:chxPXzSsl7ZWRAuOIE23GDNzjWuZquvFlgA8xmpunjU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/MarvinJWendt/testza v0.1.0/go.mod h1:7AxNvlfeHP7Z/hDQ5JtE3OKYT3XFUeLCDE2DQninSqs=
@@ -92,6 +94,8 @@ github.com/fxamacker/cbor/v2 v2.7.0 h1:iM5WgngdRBanHcxugY4JySA0nk1wZorNOpTgCMedv
 github.com/fxamacker/cbor/v2 v2.7.0/go.mod h1:pxXPTn3joSm21Gbwsv0w9OSA2y1HFR9qXEeXQVeNoDQ=
 github.com/gaissmai/bart v0.18.0 h1:jQLBT/RduJu0pv/tLwXE+xKPgtWJejbxuXAR+wLJafo=
 github.com/gaissmai/bart v0.18.0/go.mod h1:JJzMAhNF5Rjo4SF4jWBrANuJfqY+FvsFhW7t1UZJ+XY=
+github.com/go-asn1-ber/asn1-ber v1.5.8-0.20250403174932-29230038a667 h1:BP4M0CvQ4S3TGls2FvczZtj5Re/2ZzkV9VwqPHH/3Bo=
+github.com/go-asn1-ber/asn1-ber v1.5.8-0.20250403174932-29230038a667/go.mod h1:hEBeB/ic+5LoWskz+yKT7vGhhPYkProFKoKdwZRWMe0=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
@@ -99,6 +103,8 @@ github.com/go-jose/go-jose/v4 v4.1.0 h1:cYSYxd3pw5zd2FSXk2vGdn9igQU2PS8MuxrCOCl0
 github.com/go-jose/go-jose/v4 v4.1.0/go.mod h1:GG/vqmYm3Von2nYiB2vGTXzdoNKE5tix5tuc6iAd+sw=
 github.com/go-json-experiment/json v0.0.0-20250223041408-d3c622f1b874 h1:F8d1AJ6M9UQCavhwmO6ZsrYLfG8zVFWfEfMS2MXPkSY=
 github.com/go-json-experiment/json v0.0.0-20250223041408-d3c622f1b874/go.mod h1:TiCD2a1pcmjd7YnhGH0f/zKNcCD06B029pHhzV23c2M=
+github.com/go-ldap/ldap/v3 v3.4.11 h1:4k0Yxweg+a3OyBLjdYn5OKglv18JNvfDykSoI8bW0gU=
+github.com/go-ldap/ldap/v3 v3.4.11/go.mod h1:bY7t0FLK8OAVpp/vV6sSlpz3EQDGcQwc8pF0ujLgKvM=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.2 h1:6pFjapn8bFcIbiKo3XT4j/BhANplGihG6tvd+8rYgrY=
 github.com/go-logr/logr v1.4.2/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=

--- a/internal/sources/authentik.go
+++ b/internal/sources/authentik.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/yousysadmin/headscale-pf/internal/models"
-	"github.com/yousysadmin/headscale-pf/pkg/tools"
-	api "goauthentik.io/api/v3"
 	"net/http"
 	"net/url"
 	"strings"
+
+	"github.com/yousysadmin/headscale-pf/internal/models"
+	"github.com/yousysadmin/headscale-pf/pkg/tools"
+	api "goauthentik.io/api/v3"
 )
 
 // Authentik source

--- a/internal/sources/ldap.go
+++ b/internal/sources/ldap.go
@@ -1,0 +1,360 @@
+package sources
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"strings"
+	"time"
+
+	ldap "github.com/go-ldap/ldap/v3"
+
+	"github.com/yousysadmin/headscale-pf/internal/models"
+)
+
+// LDAP implements Source for LDAP directories (AD / OpenLDAP / JumpCloud LDAPaaS).
+// It supports:
+//   - groupOfNames / group via "member" / "uniqueMember" (DN-valued)
+//   - posixGroup via "memberUid" (login name / uid-valued)
+type LDAP struct {
+	Addr     string // "host:389" or "host:636"
+	UseTLS   bool   // true for LDAPS on 636 (preferred). If false, StartTLS is attempted.
+	BindDN   string
+	BindPass string
+	BaseDN   string
+
+	// Attribute preferences (override if your directory differs)
+	GroupNameAttr      string   // usually "cn"
+	UserEmailAttr      string   // AD: "mail" (or "userPrincipalName"); OpenLDAP/JumpCloud: "mail"
+	UserLoginAttrs     []string // tried in order to produce username: e.g. ["sAMAccountName","uid","cn"]
+	GroupMemberAttrs   []string // for DN members: ["member","uniqueMember"]
+	PosixMemberUidAttr string   // for posixGroup usernames: "memberUid"
+	UserObjectClasses  []string // e.g. ["person","organizationalPerson","user","inetOrgPerson"]
+	GroupObjectClasses []string // e.g. ["groupOfNames","group","posixGroup"]
+
+	// When true, if a member is a group DN, expand one level (NOT recursive).
+	ExpandOneLevelNested bool
+
+	// Domain used to synthesize an email when none is present (username@DefaultEmailDomain).
+	DefaultEmailDomain string
+}
+
+// NewLDAPClient constructs an LDAP client with sensible defaults.
+func NewLDAPClient(config SourceConfig) (*LDAP, error) {
+	if config.Endpoint == "" {
+		return nil, fmt.Errorf("ldap endpoint must be specified (e.g. ldap.jumpcloud.com:636)")
+	}
+	if config.LDAPBindDN == "" {
+		return nil, fmt.Errorf("ldap bind DN must be specified (e.g. uid=svc,ou=Users,o=<ORG_ID>,dc=jumpcloud,dc=com)")
+	}
+	if config.LDAPBaseDN == "" {
+		return nil, fmt.Errorf("ldap base DN must be specified (e.g. o=<ORG_ID>,dc=jumpcloud,dc=com)")
+	}
+	if config.LDAPBindPassword == "" {
+		return nil, fmt.Errorf("ldap bind password must be specified")
+	}
+	if config.LDAPDefaultEmailDomain == "" {
+		config.LDAPDefaultEmailDomain = "example.com"
+	}
+
+	return &LDAP{
+		Addr:     config.Endpoint,
+		UseTLS:   strings.HasSuffix(strings.ToLower(config.Endpoint), ":636"),
+		BindDN:   config.LDAPBindDN,
+		BaseDN:   config.LDAPBaseDN,
+		BindPass: config.LDAPBindPassword,
+
+		GroupNameAttr:        "cn",
+		UserEmailAttr:        "mail",
+		UserLoginAttrs:       []string{"sAMAccountName", "uid", "cn"},
+		GroupMemberAttrs:     []string{"member", "uniqueMember"},
+		PosixMemberUidAttr:   "memberUid",
+		UserObjectClasses:    []string{"person", "organizationalPerson", "user", "inetOrgPerson"},
+		GroupObjectClasses:   []string{"groupOfNames", "group", "posixGroup"},
+		ExpandOneLevelNested: false,
+		DefaultEmailDomain:   config.LDAPDefaultEmailDomain,
+	}, nil
+}
+
+// GetGroupByName finds the first group whose GroupNameAttr (default "cn")
+// exactly matches the provided groupName. It returns the group's DN as ID.
+func (c *LDAP) GetGroupByName(groupName string) (*models.Group, error) {
+	conn, err := c.connect()
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Close()
+
+	filter := fmt.Sprintf(
+		"(&(|%s)(%s=%s))",
+		c.joinOC(c.GroupObjectClasses),
+		ldap.EscapeFilter(c.GroupNameAttr),
+		ldap.EscapeFilter(groupName),
+	)
+
+	req := ldap.NewSearchRequest(
+		c.BaseDN,
+		ldap.ScopeWholeSubtree, ldap.NeverDerefAliases, 1, 10, false,
+		filter,
+		[]string{"dn", c.GroupNameAttr},
+		nil,
+	)
+
+	sr, err := conn.SearchWithPaging(req, 50)
+	if err != nil {
+		return nil, fmt.Errorf("search group by name: %w", err)
+	}
+	if len(sr.Entries) == 0 {
+		return nil, nil
+	}
+	entry := sr.Entries[0]
+	name := entry.GetAttributeValue(c.GroupNameAttr)
+	return &models.Group{
+		ID:   entry.DN, // group ID = DN
+		Name: name,
+	}, nil
+}
+
+// GetGroupMembers returns users in the group identified by groupID (expected to be a DN).
+// For posixGroup, it resolves memberUid logins to user entries.
+// For groupOfNames/group, it resolves each member DN to a user entry.
+// If ExpandOneLevelNested is true, a member that is itself a group will be expanded one level.
+func (c *LDAP) GetGroupMembers(groupID string, stripEmailDomain bool) ([]models.User, error) {
+	conn, err := c.connect()
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Close()
+
+	// Load the group entry by DN
+	groupReq := ldap.NewSearchRequest(
+		groupID, // group's DN
+		ldap.ScopeBaseObject, ldap.NeverDerefAliases, 1, 10, false,
+		"(objectClass=*)",
+		append([]string{"objectClass", c.PosixMemberUidAttr}, c.GroupMemberAttrs...),
+		nil,
+	)
+	gsr, err := conn.Search(groupReq)
+	if err != nil || len(gsr.Entries) == 0 {
+		return nil, fmt.Errorf("resolve group DN %q: %w", groupID, err)
+	}
+	group := gsr.Entries[0]
+	oc := strings.ToLower(strings.Join(group.GetAttributeValues("objectClass"), " "))
+
+	users := make([]models.User, 0)
+
+	// posixGroup via memberUid (already usernames)
+	if strings.Contains(oc, "posixgroup") {
+		memberUids := group.GetAttributeValues(c.PosixMemberUidAttr)
+		for _, u := range memberUids {
+			user, err := c.lookupUserByLogin(conn, u, stripEmailDomain)
+			if err != nil {
+				// Skip missing users, keep going
+				continue
+			}
+			users = append(users, user)
+		}
+		return users, nil
+	}
+
+	// member/uniqueMember DNs
+	memberDNs := make([]string, 0, 32)
+	for _, a := range c.GroupMemberAttrs {
+		memberDNs = append(memberDNs, group.GetAttributeValues(a)...)
+	}
+
+	// Expand one level of nested groups
+	if c.ExpandOneLevelNested && len(memberDNs) > 0 {
+		expanded := make([]string, 0, len(memberDNs))
+		for _, dn := range memberDNs {
+			isGroup, err := c.dnIsGroup(conn, dn)
+			if err != nil {
+				continue
+			}
+			if !isGroup {
+				expanded = append(expanded, dn)
+				continue
+			}
+			// Pull inner members (only one level)
+			req := ldap.NewSearchRequest(
+				dn,
+				ldap.ScopeBaseObject, ldap.NeverDerefAliases, 1, 10, false,
+				"(objectClass=*)",
+				c.GroupMemberAttrs,
+				nil,
+			)
+			sr, err := conn.Search(req)
+			if err != nil || len(sr.Entries) == 0 {
+				continue
+			}
+			for _, a := range c.GroupMemberAttrs {
+				expanded = append(expanded, sr.Entries[0].GetAttributeValues(a)...)
+			}
+		}
+		memberDNs = expanded
+	}
+
+	// Resolve DN members to users with a timeout guard
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	for _, dn := range memberDNs {
+		select {
+		case <-ctx.Done():
+			return users, ctx.Err()
+		default:
+		}
+		u, err := c.lookupUserByDN(conn, dn, stripEmailDomain)
+		if err == nil {
+			users = append(users, u)
+		}
+	}
+	return users, nil
+}
+
+// GetUserInfo resolves a user by ID. If userID looks like a DN, it loads that DN.
+// Otherwise it treats userID as a login (sAMAccountName/uid/cn—config-driven) and searches.
+func (c *LDAP) GetUserInfo(userID string, stripEmailDomain bool) (models.User, error) {
+	conn, err := c.connect()
+	if err != nil {
+		return models.User{}, err
+	}
+	defer conn.Close()
+
+	// DN path
+	if strings.Contains(userID, "=") && strings.Contains(userID, ",") {
+		return c.lookupUserByDN(conn, userID, stripEmailDomain)
+	}
+	// Otherwise treat as login name (uid/sAMAccountName/cn)
+	return c.lookupUserByLogin(conn, userID, stripEmailDomain)
+}
+
+// connect dials the LDAP server and performs a simple bind.
+// If UseTLS is false, it attempts StartTLS (best-effort).
+func (c *LDAP) connect() (*ldap.Conn, error) {
+	var conn *ldap.Conn
+	var err error
+	if c.UseTLS {
+		conn, err = ldap.DialTLS("tcp", c.Addr, &tls.Config{MinVersion: tls.VersionTLS12})
+	} else {
+		conn, err = ldap.Dial("tcp", c.Addr)
+		if err == nil {
+			_ = conn.StartTLS(&tls.Config{InsecureSkipVerify: true})
+		}
+	}
+	if err != nil {
+		return nil, fmt.Errorf("ldap dial: %w", err)
+	}
+	if err := conn.Bind(c.BindDN, c.BindPass); err != nil {
+		conn.Close()
+		return nil, fmt.Errorf("ldap bind: %w", err)
+	}
+	return conn, nil
+}
+
+// joinOC builds an LDAP filter fragment that ORs multiple objectClass checks.
+// For example, ["groupOfNames","group"] => "(objectClass=groupOfNames)(objectClass=group)"
+// The caller typically wraps this with an enclosing "(| ... )".
+func (c *LDAP) joinOC(classes []string) string {
+	parts := make([]string, 0, len(classes))
+	for _, oc := range classes {
+		parts = append(parts, fmt.Sprintf("(objectClass=%s)", ldap.EscapeFilter(oc)))
+	}
+	return strings.Join(parts, "")
+}
+
+// dnIsGroup returns true if the entry at the given DN has an objectClass that
+// matches any name in GroupObjectClasses. It uses a base-object search to avoid
+// scanning the tree.
+func (c *LDAP) dnIsGroup(conn *ldap.Conn, dn string) (bool, error) {
+	req := ldap.NewSearchRequest(
+		dn, ldap.ScopeBaseObject, ldap.NeverDerefAliases, 1, 5, false,
+		"(objectClass=*)", []string{"objectClass"}, nil,
+	)
+	sr, err := conn.Search(req)
+	if err != nil || len(sr.Entries) == 0 {
+		return false, err
+	}
+	oc := strings.ToLower(strings.Join(sr.Entries[0].GetAttributeValues("objectClass"), " "))
+	for _, g := range c.GroupObjectClasses {
+		if strings.Contains(oc, strings.ToLower(g)) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// lookupUserByDN fetches a user entry by its DN (base-object search) and maps
+// it into models.User via entryToUser.
+func (c *LDAP) lookupUserByDN(conn *ldap.Conn, dn string, stripEmailDomain bool) (models.User, error) {
+	req := ldap.NewSearchRequest(
+		dn,
+		ldap.ScopeBaseObject, ldap.NeverDerefAliases, 1, 5, false,
+		"(objectClass=*)",
+		append([]string{"dn", c.UserEmailAttr}, c.UserLoginAttrs...),
+		nil,
+	)
+	sr, err := conn.Search(req)
+	if err != nil || len(sr.Entries) == 0 {
+		return models.User{}, fmt.Errorf("user DN %q not found", dn)
+	}
+	e := sr.Entries[0]
+	return c.entryToUser(e, stripEmailDomain), nil
+}
+
+// lookupUserByLogin searches the directory subtree (BaseDN) for a user whose
+// login attributes (UserLoginAttrs) equal the provided login. It limits results
+// to avoid ambiguity and returns the first match mapped via entryToUser.
+func (c *LDAP) lookupUserByLogin(conn *ldap.Conn, login string, stripEmailDomain bool) (models.User, error) {
+	// Build an OR filter across allowed user objectClasses and login attrs
+	loginFilterParts := make([]string, 0, len(c.UserLoginAttrs))
+	for _, a := range c.UserLoginAttrs {
+		loginFilterParts = append(loginFilterParts, fmt.Sprintf("(%s=%s)", ldap.EscapeFilter(a), ldap.EscapeFilter(login)))
+	}
+	filter := fmt.Sprintf("(&(|%s)(|%s))", c.joinOC(c.UserObjectClasses), strings.Join(loginFilterParts, ""))
+
+	req := ldap.NewSearchRequest(
+		c.BaseDN,
+		ldap.ScopeWholeSubtree, ldap.NeverDerefAliases, 2, 10, false,
+		filter,
+		append([]string{"dn", c.UserEmailAttr}, c.UserLoginAttrs...),
+		nil,
+	)
+	sr, err := conn.SearchWithPaging(req, 50)
+	if err != nil || len(sr.Entries) == 0 {
+		return models.User{}, fmt.Errorf("user %q not found", login)
+	}
+	return c.entryToUser(sr.Entries[0], stripEmailDomain), nil
+}
+
+// entryToUser converts an LDAP entry into models.User.
+// It picks the first non-empty attribute from UserLoginAttrs as "username" and
+// prefers UserEmailAttr for the email. If the email is absent but a username is
+// available and DefaultEmailDomain is set, it synthesizes username@DefaultEmailDomain.
+// When stripEmailDomain is true and the email contains "@", only the local part is returned.
+func (c *LDAP) entryToUser(e *ldap.Entry, stripEmailDomain bool) models.User {
+	// Username (preferred attr in order)
+	var username string
+	for _, a := range c.UserLoginAttrs {
+		if v := e.GetAttributeValue(a); v != "" {
+			username = v
+			break
+		}
+	}
+
+	// Email (fallback: synthesize from username)
+	email := e.GetAttributeValue(c.UserEmailAttr)
+	if email == "" && username != "" && c.DefaultEmailDomain != "" {
+		email = fmt.Sprintf("%s@%s", username, c.DefaultEmailDomain)
+	}
+	if stripEmailDomain && strings.Contains(email, "@") {
+		email = strings.Split(email, "@")[0] + "@"
+	}
+
+	// Map to your models.User. Adjust field names if they differ.
+	return models.User{
+		ID:    e.DN,  // user ID = DN
+		Email: email, // or Username/Name depending on models.User
+		Part:  email,
+	}
+}

--- a/internal/sources/sources.go
+++ b/internal/sources/sources.go
@@ -2,6 +2,7 @@ package sources
 
 import (
 	"fmt"
+
 	"github.com/yousysadmin/headscale-pf/internal/models"
 )
 
@@ -14,11 +15,13 @@ type Source interface {
 
 // SourceConfig config source
 type SourceConfig struct {
-	Name     string // Name source name
-	Endpoint string // Endpoint source endpoint
-	Username string // Username source auth username
-	Password string // Password source auth password
-	Token    string // Token source auth token
+	Name                   string // Name source name
+	Endpoint               string // Endpoint source endpoint
+	Token                  string // Token source auth token
+	LDAPBindPassword       string // LDAP bind password
+	LDAPBindDN             string // LDAP BindDN
+	LDAPBaseDN             string // LDAP BaseDN
+	LDAPDefaultEmailDomain string // Default email domain what used for synthesize an email when none is present (username@DefaultEmailDomain).
 }
 
 // NewSource init source
@@ -28,6 +31,8 @@ func NewSource(config SourceConfig) (Source, error) {
 		return NewJCClient(config)
 	case "ak":
 		return NewAuthentikClient(config)
+	case "ldap", "ldaps":
+		return NewLDAPClient(config)
 	default:
 		return nil, fmt.Errorf("unknown source name")
 	}

--- a/pkg/term-color/term-color.go
+++ b/pkg/term-color/term-color.go
@@ -1,8 +1,9 @@
 package term_color
 
 import (
-	"github.com/jagottsicher/termcolor"
 	"os"
+
+	"github.com/jagottsicher/termcolor"
 )
 
 // CheckTerminalColorSupport checking terminal color support


### PR DESCRIPTION
New flags

```
--ldap-base-dn string                Base DN to use for LDAP searches (can use env var PF_LDAP_BASE_DN)
--ldap-bind-dn string                Distinguished Name of the LDAP bind user account (can use env var PF_LDAP_BIND_DN)
--ldap-bind-password string          LDAP password (can use env var PF_LDAP_BIND_PASSWORD)
--ldap-default-email-domain string   Default email domain to append when user entries lack a mail attribute (can use env var PF_LDAP_DEFAULT_USER_EMAIL_DOMAIN)
```